### PR TITLE
Section "Functions as values": Wrong error reported by console in 4th example of "JavaScript functions can be returned by functions" sub-paragraph.

### DIFF
--- a/chapters/functions/Readme.md
+++ b/chapters/functions/Readme.md
@@ -253,7 +253,7 @@ JavaScript functions can be returned by functions.
 > greets()()();
 > //"Hello!"
 > //"Bye!"
-> // TypeError: object is not a function
+> // TypeError: undefined is not a function
 > ```
 
 ## Self-invoking functions


### PR DESCRIPTION
The 'correct error' is "TypeError: <i>undefined</i> is not a function", not "TypeError: object is not a function".
